### PR TITLE
Added `pfx` to the "HTTPS options restore" section

### DIFF
--- a/source/core/index.ts
+++ b/source/core/index.ts
@@ -2424,6 +2424,10 @@ export default class Request extends Duplex implements RequestEvents<Request> {
 				if (options.https.passphrase) {
 					delete requestOptions.passphrase;
 				}
+
+				if (options.https.pfx) {
+					delete requestOptions.pfx;
+				}
 			}
 
 			if (isClientRequest(requestOrResponse)) {


### PR DESCRIPTION
This time it should be ok :)

I've merged the commit fixing the DeprecationWarning on retry and then added `pfx` to the fixed options.

Commit: https://github.com/markdboyd/got/commit/9a309bdbe7e2552c5bffbea253d58c39d6e6c3e3
Comment on PR: https://github.com/sindresorhus/got/pull/1364#issuecomment-682592072